### PR TITLE
fix: Change User model fillable field from 'fullname' to 'name'

### DIFF
--- a/app/models/User.php
+++ b/app/models/User.php
@@ -9,7 +9,7 @@ class User extends Model
      * @var array
      */
     protected $fillable = [
-        'fullname', 'email', 'password',
+        'name', 'email', 'password',
     ];
 
     /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

This PR fixes an inconsistency in field naming between the User model and its related files in v3.x branch:

Current state:
- [app/models/User.php](cci:7://file:///tmp/leaf-pr/leafMVC/app/models/User.php:0:0-0:0) uses 'fullname' in $fillable
- Migration template uses 'name'
- Schema JSON example uses 'name'

This inconsistency could cause confusion for new users as the default model doesn't match the schema. When users follow the default migration or schema examples, they'll encounter issues because the User model expects 'fullname' while the database has 'name'.

Changes made:
- Changed 'fullname' to 'name' in User model's $fillable array to maintain consistency with:
  - Default migration template
  - Schema JSON example
  - Laravel's convention of using 'name'

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Related Issue

This issue was discovered while implementing authentication in a new Leaf MVC project. There was no existing issue for this inconsistency.

The fix aligns the User model with:
1. The default migration template in `app/database/migrations/2019_11_18_133625_create_users.php`
2. The schema example in `app/database/schema/users.json`
3. Laravel's convention of using 'name' for the user's name field