### PR TITLE
fix: update db factory and seeds to match schema

### DIFF
--- a/app/database/factories/UserFactory.php
+++ b/app/database/factories/UserFactory.php
@@ -15,8 +15,7 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'username' => strtolower($this->faker->firstName),
-            'fullname' => $this->faker->name,
+            'name' => strtolower($this->faker->firstName),
             'email' => $this->faker->unique()->safeEmail,
             'email_verified_at' => tick()->now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password

--- a/app/database/seeds/UsersSeeder.php
+++ b/app/database/seeds/UsersSeeder.php
@@ -16,8 +16,7 @@ class UsersSeeder extends Seeder
         // You can directly create db records like this 👇
 
         // $user = new User();
-        // $user->username = 'mychi';
-        // $user->fullname = 'Mychi Darko';
+        // $user->name = 'mychi';
         // $user->email = 'mychi@leafphp.dev';
         // $user->password = \Leaf\Password::hash('password');
         // $user->save();


### PR DESCRIPTION
## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

The User schema was recently changed (`username -> name` and `fullname` was removed) but the UserFactory still has the old schema. This makes `db:seed` and `db:reset` fail.

The change updates to the new schema.

## Does this PR introduce a breaking change? (check one)

- [ ] Yes
- [x] No

## Related Issue

N/A